### PR TITLE
Convert result of `map` to `list`.

### DIFF
--- a/dt.pyx
+++ b/dt.pyx
@@ -77,7 +77,7 @@ def compute(x, axes=None, f=L2):
     numel  = shape[axis]
     minbuf = np.empty((numel,), dtype=float)
     argbuf = np.empty((numel,), dtype=int)
-    slices = map(xrange, shape)
+    slices = list(map(xrange, shape))
     slices[axis] = [Ellipsis]
 
     for index in itertools.product(*slices):


### PR DESCRIPTION
In Python 3, `map` returns a map object instead of a list. This means that the assignment on the next line fails with the message `TypeError: 'map' object does not support item assignment`.